### PR TITLE
Adding fits alignment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flask-cors>=3,<4
 requests>=2.13,<2.14
 boto3>=1.4,<1.5
 fits2image
+fits_align


### PR DESCRIPTION
This incorporates FITS alignment package, which I've called `fits_align` (instead of `lco_alipy`). The code uses `astropy` for FITS handling and accessing the sources in the FITS files. This can work along side the existing `FITSIO` install (used in `fits2image`) but I've also made a branch of `fits2image` which exclusively uses astropy  (because I couldn't get FITSIO installed locally) - https://github.com/LCOGT/fits2image/tree/astropy

The only other dependencies are `PIL/PIllow` and `numpy` (managed to totally get rid of `scipy`!).

`fits_align` isn't in our local pypi because I couldn't work out how to make Jenkins build it, but you can test and build it from here - https://github.com/LCOGT/fits_align

