### PR TITLE
Feature/various updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .git
+.idea
 scratch/
+__pycache__/
+.pytest_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /var/www/thumbservice
 
 COPY requirements.txt /var/www/thumbservice
 RUN apk --no-cache add freetype libjpeg-turbo libpng ttf-dejavu zlib \
-        && apk --no-cache add --virtual .build-deps freetype-dev gcc libjpeg-turbo-dev libpng-dev make musl-dev zlib-dev \
+        && apk --no-cache add --virtual .build-deps freetype-dev gcc libjpeg-turbo-dev libpng-dev make musl-dev zlib-dev openssl-dev libffi-dev \
         && pip --no-cache-dir install "numpy>=1.16,<1.17" \
         && pip --no-cache-dir install -r /var/www/thumbservice/requirements.txt --trusted-host=buildsba.lco.gtn \
         && apk --no-cache del .build-deps

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ in your virtualenv.
 
 All other dependencies are listed in the requirements.txt file and can be installed with pip.
 
+Run the tests with `pytest tests.py`.
+
 ## Authorization
 
 The api passes through the `Authorization` header to the archive API. You only need to provide

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ in the archive, and `basename` is the base part of the filename (no file extensi
 a thumbnail of. Using the frame_id is faster to return if you happen to know it
 ahead of time.
 
-Both endpoints take 3 query parameters:
+Both endpoints take the following query parameters:
 
 * width
 * height

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 numpy>=1.16,<1.17
 flask>=1.0.0,<1.1.0
 flask-cors>=3,<4
-requests>=2.20,<2.21
+requests>=2.21,<2.22
 boto3>=1.9,<1.10
 fits2image
 fits_align

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,13 @@
 --extra-index-url=http://buildsba.lco.gtn/python
 numpy>=1.16,<1.17
-flask>=0.12,<0.13
+flask>=1.0.0,<1.1.0
 flask-cors>=3,<4
 requests>=2.20,<2.21
-boto3>=1.4,<1.5
+boto3>=1.9,<1.10
 fits2image
 fits_align
 gunicorn[gevent]==19.9.0
+
+pytest
+requests_mock
+moto==1.3.7

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,274 @@
+import mock
+from pathlib import Path
+from collections import namedtuple
+
+import boto3
+import pytest
+import requests
+from moto import mock_s3
+
+import thumbservice
+
+TEST_API_URL = 'https://test-archive-api.lco.gtn/'
+TEST_BUCKET = 'test_bucket'
+TEST_ACCESS_KEY = 'test_secret_key'
+TEST_SECRET_ACCESS_KEY = 'test_secret_access_key'
+
+_test_data = {
+    'frame': {
+        'OBSTYPE': 'EXPOSE',
+        'filename': 'ogg0m404-kb82-20190321-0273-e91.fits.fz',
+        'id': 11245132,
+        'url': 'http://file_url',
+        'PROPID': 'LCOEPO2018B-002',
+        'REQNUM': 1756835,
+        'FILTER': 'B'
+    },
+    'request_frames': {
+        'count': 6,
+        'results': [
+            {
+                'OBSTYPE': 'EXPOSE',
+                'filename': 'ogg0m404-kb82-20190321-0273-e91.fits.fz',
+                'id': 11245132,
+                'url': 'http://file_url_1',
+                'PROPID': 'LCOEPO2018B-002',
+                'REQNUM': 1756835,
+                'FILTER': 'B',
+                'RLEVEL': 91
+            },
+            {
+                'OBSTYPE': 'EXPOSE',
+                'filename': 'ogg0m404-kb82-20190321-0273-e00.fits.fz',
+                'id': 11245129,
+                'url': 'http://file_url_2',
+                'PROPID': 'LCOEPO2018B-002',
+                'REQNUM': 1756835,
+                'FILTER': 'B',
+                'RLEVEL': 0
+            },
+            {
+                'OBSTYPE': 'EXPOSE',
+                'filename': 'ogg0m404-kb82-20190321-0272-e91.fits.fz',
+                'id': 11245120,
+                'url': 'http://file_url_3',
+                'PROPID': 'LCOEPO2018B-002',
+                'REQNUM': 1756835,
+                'FILTER': 'V',
+                'RLEVEL': 91
+            },
+            {
+                'OBSTYPE': 'EXPOSE',
+                'filename': 'ogg0m404-kb82-20190321-0272-e00.fits.fz',
+                'id': 11245119,
+                'url': 'http://file_url_4',
+                'PROPID': 'LCOEPO2018B-002',
+                'REQNUM': 1756835,
+                'FILTER': 'V',
+                'RLEVEL': 0
+            },
+            {
+                'OBSTYPE': 'EXPOSE',
+                'filename': 'ogg0m404-kb82-20190321-0271-e91.fits.fz',
+                'id': 11245105,
+                'url': 'http://file_url_5',
+                'PROPID': 'LCOEPO2018B-002',
+                'REQNUM': 1756835,
+                'FILTER': 'rp',
+                'RLEVEL': 91
+            },
+            {
+                'OBSTYPE': 'EXPOSE',
+                'filename': 'ogg0m404-kb82-20190321-0271-e00.fits.fz',
+                'id': 11245103,
+                'url': 'http://file_url_6',
+                'PROPID': 'LCOEPO2018B-002',
+                'REQNUM': 1756835,
+                'FILTER': 'rp',
+                'RLEVEL': 0
+            },
+        ]
+    }
+}
+
+
+@pytest.fixture(autouse=True)
+def set_test_values(tmp_path):
+    thumbservice.settings = thumbservice.Settings(
+        settings={
+            'TMP_DIR': tmp_path,
+            'ARCHIVE_API': TEST_API_URL,
+            'AWS_S3_BUCKET': TEST_BUCKET,
+            'AWS_ACCESS_KEY_ID': TEST_ACCESS_KEY,
+            'AWS_SECRET_ACCESS_KEY': TEST_SECRET_ACCESS_KEY
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_fits_to_jpeg():
+    def side_effect(*args, **kwargs):
+        Path(args[1]).touch()
+    m = thumbservice.fits_to_jpg = mock.MagicMock()
+    m.side_effect = side_effect
+
+
+@pytest.fixture(autouse=True)
+def mock_affineremap(tmp_path):
+    def side_effect(*args, **kwargs):
+        path = tmp_path / Path(args[0]).with_suffix('.affineremap')
+        path.touch()
+        return str(path)
+    m = thumbservice.affineremap = mock.MagicMock()
+    m.side_effect = side_effect
+
+
+@pytest.fixture(autouse=True)
+def mock_make_transforms():
+    def side_effect(*args, **kwargs):
+        ukn = namedtuple('Ukn', ['filepath'])
+        result = namedtuple('Result', ['ok', 'trans', 'ukn'])
+        results = []
+        for path in args[1]:
+            results.append(result(True, None, ukn(path)))
+        return results
+    m = thumbservice.make_transforms = mock.MagicMock()
+    m.side_effect = side_effect
+
+
+@pytest.fixture
+def thumbservice_client():
+    thumbservice.app.config['TESTING'] = True
+    yield thumbservice.app.test_client()
+
+
+@pytest.fixture
+def s3_client():
+    # This should be passed in to all test functions to mock out calls to aws
+    with mock_s3():
+        s3 = boto3.client('s3', aws_access_key_id=TEST_ACCESS_KEY, aws_secret_access_key=TEST_SECRET_ACCESS_KEY)
+        s3.create_bucket(Bucket=TEST_BUCKET)
+        yield s3
+
+
+def test_get_index(thumbservice_client):
+    response = thumbservice_client.get('/')
+    assert b'Please see the documentation' in response.data
+
+
+def test_generate_black_and_white_thumbnail_successfully(thumbservice_client, requests_mock, s3_client, tmp_path):
+    frame = _test_data['frame'].copy()
+    requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
+    requests_mock.get(frame['url'], content=b'I Am Image')
+    response1 = thumbservice_client.get(f'/{frame["id"]}/')
+    call_count_after_1 = requests_mock.call_count
+    response2 = thumbservice_client.get(f'/{frame["id"]}/')
+    call_count_after_2 = requests_mock.call_count
+    for response in [response1, response2]:
+        response_as_json = response.get_json()
+        assert response_as_json['propid'] == frame['PROPID']
+        assert 'url' in response_as_json
+        assert response.status_code == 200
+    # The resource will have been created in s3 on the first call, on the second call less work needs to
+    # be done, including only 1 call to requests as opposed to the 2 on initial creation
+    assert call_count_after_1 == 2
+    assert call_count_after_2 == 3
+    # All temp files should have been cleared out
+    assert len(list(tmp_path.glob('*'))) == 0
+
+
+def test_generate_color_thumbnail_successfully(thumbservice_client, requests_mock, s3_client, tmp_path):
+    frame = _test_data['frame'].copy()
+    request_frames = _test_data['request_frames'].copy()
+    requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
+    requests_mock.get(f'{TEST_API_URL}frames/?REQNUM={frame["REQNUM"]}', json=request_frames)
+    for request_frame in request_frames['results']:
+        requests_mock.get(request_frame['url'], content=b'I Am Image')
+    response1 = thumbservice_client.get(f'/{frame["id"]}/?color=true')
+    call_count_after_1 = requests_mock.call_count
+    response2 = thumbservice_client.get(f'/{frame["id"]}/?color=true')
+    call_count_after_2 = requests_mock.call_count
+    for response in [response1, response2]:
+        response_as_json = response.get_json()
+        assert response_as_json['propid'] == frame['PROPID']
+        assert 'url' in response_as_json
+        assert response.status_code == 200
+    # The resource will have been created in s3 on the first call, on the second call less work needs to
+    # be done, including only 1 call to requests as opposed to the 5 on initial creation
+    assert call_count_after_1 == 5
+    assert call_count_after_2 == 6
+    # All temp files should have been cleared out
+    assert len(list(tmp_path.glob('*'))) == 0
+
+
+def test_filters_for_color_thumbnail_not_available(thumbservice_client, requests_mock, s3_client, tmp_path):
+    frame = _test_data['frame'].copy()
+    request_frames = _test_data['request_frames'].copy()
+    request_frames['results'].pop()
+    request_frames['results'].pop()
+    requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
+    requests_mock.get(f'{TEST_API_URL}frames/?REQNUM={frame["REQNUM"]}', json=request_frames)
+    for request_frame in request_frames['results']:
+        requests_mock.get(request_frame['url'], content=b'I Am Image')
+    response = thumbservice_client.get(f'/{frame["id"]}/?color=true')
+    assert response.status_code == 404
+    assert b'RVB frames not found' in response.data
+    # All temp files should have been cleared out
+    assert len(list(tmp_path.glob('*'))) == 0
+
+
+def test_cannot_generate_thumbnail_for_non_image_obstypes(thumbservice_client, requests_mock, tmp_path, s3_client):
+    frame = _test_data['frame'].copy()
+    frame['OBSTYPE'] = 'CATALOG'
+    requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
+    response = thumbservice_client.get(f'/{frame["id"]}/')
+    assert response.status_code == 400
+    assert len(list(tmp_path.glob('*'))) == 0
+
+
+def test_cannot_generate_thumbnail_for_non_fits_file(thumbservice_client, requests_mock, tmp_path, s3_client):
+    frame = _test_data['frame'].copy()
+    frame['filename'] = 'OGG_calib_0001760408_ftn_20190331_58574.tar.gz'
+    frame['OBSTYPE'] = 'SPECTRUM'
+    requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
+    response = thumbservice_client.get(f'/{frame["id"]}/')
+    assert response.status_code == 400
+    assert len(list(tmp_path.glob('*'))) == 0
+
+
+def test_frame_not_found(thumbservice_client, requests_mock, tmp_path, s3_client):
+    frame_id = 6
+    frame = {
+        'detail': 'Not found.'
+    }
+    requests_mock.get(f'{TEST_API_URL}frames/{frame_id}/', json=frame, status_code=404)
+    response = thumbservice_client.get(f'/{frame_id}/')
+    assert response.status_code == 404
+    assert len(list(tmp_path.glob('*'))) == 0
+
+
+def test_archive_query_returned_500(thumbservice_client, requests_mock, tmp_path, s3_client):
+    frame_id = 13
+    requests_mock.get(f'{TEST_API_URL}frames/{frame_id}/', status_code=500)
+    response = thumbservice_client.get(f'/{frame_id}/')
+    assert response.status_code == 502
+    assert len(list(tmp_path.glob('*'))) == 0
+
+
+def test_archive_query_raised_exception_during_request(thumbservice_client, requests_mock, tmp_path, s3_client):
+    frame_id = 13
+    requests_mock.get(f'{TEST_API_URL}frames/{frame_id}/', exc=requests.exceptions.ConnectTimeout)
+    response = thumbservice_client.get(f'/{frame_id}/')
+    assert response.status_code == 502
+    assert len(list(tmp_path.glob('*'))) == 0
+
+
+def test_frame_basename_does_not_exist(thumbservice_client, requests_mock, tmp_path, s3_client):
+    empty_results = {
+        'count': 0,
+        'results': []
+    }
+    requests_mock.get(f'{TEST_API_URL}frames/?basename=some_frame_that_doesnt_exist', json=empty_results)
+    response = thumbservice_client.get('/some_frame_that_doesnt_exist/')
+    assert response.status_code == 404
+    assert len(list(tmp_path.glob('*'))) == 0

--- a/tests.py
+++ b/tests.py
@@ -251,7 +251,7 @@ def test_cannot_generate_thumbnail_for_non_fits_file(thumbservice_client, reques
     requests_mock.get(f'{TEST_API_URL}frames/{frame["id"]}/', json=frame)
     response = thumbservice_client.get(f'/{frame["id"]}/')
     assert response.status_code == 400
-    assert 'Cannot generate thumbnail for non FITS-type image' in response.get_json()['message']
+    assert 'Cannot generate thumbnail for non FITS-type frame' in response.get_json()['message']
     assert len(list(tmp_path.glob('*'))) == 0
 
 

--- a/thumbservice.py
+++ b/thumbservice.py
@@ -122,7 +122,7 @@ def key_for_jpeg(frame_id, **params):
 
 
 def convert_to_jpg(paths, key, **params):
-    jpg_path = os.path.dirname(paths[0]) + '/' + get_unique_id() + '-' + key
+    jpg_path = f'{os.path.dirname(paths[0])}/{get_unique_id()}-{key}'
     fits_to_jpg(paths, jpg_path, **params)
     return jpg_path
 

--- a/thumbservice.py
+++ b/thumbservice.py
@@ -216,7 +216,7 @@ def reproject_files(ref_image, images_to_align):
 
 
 class Paths:
-    """Keep a record of all paths ever set"""
+    """Retain all paths set"""
     def __init__(self):
         self._all_paths = set()
         self.paths = []

--- a/thumbservice.py
+++ b/thumbservice.py
@@ -1,43 +1,146 @@
 #!/usr/bin/env python
-from flask import Flask, request, abort, jsonify, redirect
-from flask_cors import CORS
-import requests
 import os
+import uuid
+
 import boto3
+import requests
+from flask_cors import CORS
+from flask import Flask, request, jsonify, redirect
 from fits2image.conversions import fits_to_jpg
 from fits_align.ident import make_transforms
 from fits_align.align import affineremap
+
 app = Flask(__name__)
 CORS(app)
 
-ARCHIVE_API = 'https://archive-api.lco.global/'
-TMP_DIR = os.getenv('TMP_DIR', '/tmp/')
-BUCKET = os.getenv('AWS_S3_BUCKET', 'lcogtthumbnails')
+IMAGE_OBSTYPES = (
+    'ARC',
+    'BIAS',
+    'BPM',
+    'DARK',
+    'DOUBLE',
+    'EXPERIMENTAL',
+    'EXPOSE',
+    'GUIDE',
+    'LAMPFLAT',
+    'SKYFLAT',
+    'SPECTRUM',
+    'STANDARD',
+    'TARGET',
+    'TRAILED',
+)
+
+
+class Settings:
+    def __init__(self, settings=None):
+        self._settings = settings or {}
+
+        self.ARCHIVE_API = self.set_value('ARCHIVE_API', 'https://archive-api.lco.global/', True)
+        self.TMP_DIR = self.set_value('TMP_DIR', '/tmp/', True)
+        self.BUCKET = self.set_value('AWS_S3_BUCKET', 'lcogtthumbnails')
+        self.AWS_ACCESS_KEY_ID = self.set_value('AWS_ACCESS_KEY_ID', 'changeme')
+        self.AWS_SECRET_ACCESS_KEY = self.set_value('AWS_SECRET_ACCESS_KEY', 'changeme')
+        # Using `None` for `STORAGE_URL` will connect to AWS
+        self.STORAGE_URL = self.set_value('STORAGE_URL', None)
+
+    def set_value(self, env_var, default, must_end_with_slash=False):
+        if env_var in self._settings:
+            value = self._settings[env_var]
+        else:
+            value = os.getenv(env_var, default)
+        return self.end_with_slash(value) if must_end_with_slash else value
+
+    @staticmethod
+    def end_with_slash(path):
+        return os.path.join(path, '')
+
+
+settings = Settings()
+
+
+class ThumbnailAppException(Exception):
+    status_code = 500
+
+    def __init__(self, message, status_code=None, payload=None):
+        Exception.__init__(self)
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        self.payload = payload
+
+    def to_dict(self):
+        result = dict(self.payload or ())
+        result['message'] = self.message
+        return result
+
+
+@app.errorhandler(ThumbnailAppException)
+def handle_thumbnail_app_exception(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response
+
+
+def get_response(url, params=None, headers=None):
+    response = None
+    try:
+        response = requests.get(url, headers=headers, params=params)
+        response.raise_for_status()
+    except requests.RequestException:
+        status_code = getattr(response, 'status_code', None)
+        payload = {'url': url}
+        if status_code is None or 500 <= status_code < 600:
+            status_code = 502
+        else:
+            try:
+                payload['response'] = response.json()
+            except:
+                pass
+        raise ThumbnailAppException('Got invalid response', status_code=status_code, payload=payload)
+    return response
+
+
+def get_unique_id():
+    return uuid.uuid4().hex
+
+
+def can_generate_thumbnail_on(frame):
+    is_fits = any([frame.get('filename', '').endswith(ext) for ext in ['.fits', '.fits.fz']])
+    is_correct_obstype = frame.get('OBSTYPE', '').upper() in IMAGE_OBSTYPES
+    return is_correct_obstype and is_fits
 
 
 def save_temp_file(frame):
-    path = TMP_DIR + frame['filename']
+    path = f'{settings.TMP_DIR}{get_unique_id()}-{frame["filename"]}'
     with open(path, 'wb') as f:
-        f.write(requests.get(frame['url']).content)
+        f.write(get_response(frame['url']).content)
     return path
 
 
 def key_for_jpeg(frame_id, **params):
-    return '{0}.{1}.jpg'.format(frame_id, hash(frozenset(params.items())))
+    return f'{frame_id}.{hash(frozenset(params.items()))}.jpg'
 
 
 def convert_to_jpg(paths, key, **params):
-    jpg_path = os.path.dirname(paths[0]) + '/' + key
+    jpg_path = os.path.dirname(paths[0]) + '/' + get_unique_id() + '-' + key
     fits_to_jpg(paths, jpg_path, **params)
     return jpg_path
 
 
-def upload_to_s3(jpg_path):
-    key = os.path.basename(jpg_path)
-    client = boto3.client('s3')
+def get_s3_client():
+    return boto3.client(
+        's3',
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        endpoint_url=settings.STORAGE_URL
+    )
+
+
+def upload_to_s3(key, jpg_path):
+    client = get_s3_client()
     with open(jpg_path, 'rb') as f:
         client.put_object(
-            Bucket=BUCKET,
+            Bucket=settings.BUCKET,
             Body=f,
             Key=key,
             ContentType='image/jpeg'
@@ -45,18 +148,18 @@ def upload_to_s3(jpg_path):
 
 
 def generate_url(key):
-    client = boto3.client('s3')
+    client = get_s3_client()
     return client.generate_presigned_url(
         'get_object',
         ExpiresIn=3600 * 8,
-        Params={'Bucket': BUCKET, 'Key': key}
+        Params={'Bucket': settings.BUCKET, 'Key': key}
     )
 
 
 def key_exists(key):
-    client = boto3.client('s3')
+    client = get_s3_client()
     try:
-        client.head_object(Bucket=BUCKET, Key=key)
+        client.head_object(Bucket=settings.BUCKET, Key=key)
         return True
     except:
         return False
@@ -66,8 +169,9 @@ def frames_for_requestnum(reqnum, request):
     headers = {
         'Authorization': request.headers.get('Authorization')
     }
-    frames = requests.get(
-        '{0}frames/?REQNUM={1}'.format(ARCHIVE_API, reqnum),
+    frames = get_response(
+        f'{settings.ARCHIVE_API}frames/',
+        params={'REQNUM': reqnum},
         headers=headers
     ).json()['results']
     if any(f for f in frames if f['RLEVEL'] == 91):
@@ -85,7 +189,6 @@ def rvb_frames(frames):
         'visual': ['V'],
         'blue': ['B'],
     }
-
     selected_frames = []
     for color in ['red', 'visual', 'blue']:
         try:
@@ -93,8 +196,9 @@ def rvb_frames(frames):
                 next(f for f in frames if f['FILTER'] in FILTERS[color])
             )
         except StopIteration:
-            abort(404)
+            raise ThumbnailAppException('RVB frames not found', status_code=404)
     return selected_frames
+
 
 def reproject_files(ref_image, images_to_align):
     identifications = make_transforms(ref_image, images_to_align[1:3])
@@ -102,13 +206,30 @@ def reproject_files(ref_image, images_to_align):
     aligned_images = []
     for id in identifications:
         if id.ok:
-            aligned_img = affineremap(id.ukn.filepath, id.trans, outdir=TMP_DIR)
+            aligned_img = affineremap(id.ukn.filepath, id.trans, outdir=settings.TMP_DIR)
             aligned_images.append(aligned_img)
 
     img_list = [ref_image]+aligned_images
     if len(img_list) != 3:
         return images_to_align
     return img_list
+
+
+class Paths:
+    """Keep a record of all paths ever set"""
+    def __init__(self):
+        self._all_paths = set()
+        self.paths = []
+
+    def set(self, paths):
+        for path in paths:
+            self._all_paths.add(path)
+        self.paths = paths
+
+    @property
+    def all_paths(self):
+        return list(self._all_paths)
+
 
 def generate_thumbnail(frame, request):
     params = {
@@ -125,26 +246,30 @@ def generate_thumbnail(frame, request):
         return generate_url(key)
     # Cfitsio is a bit crappy and can only read data off disk
     jpg_path = None
-    paths = []
+    paths = Paths()
     try:
         if not params['color']:
-            paths = [save_temp_file(frame)]
+            paths.set([save_temp_file(frame)])
         else:
             reqnum_frames = frames_for_requestnum(frame['REQNUM'], request)
-            paths = [save_temp_file(frame) for frame in rvb_frames(reqnum_frames)]
-            paths = reproject_files(paths[0], paths)
-        jpg_path = convert_to_jpg(paths, key, **params)
-        upload_to_s3(jpg_path)
+            paths.set([save_temp_file(frame) for frame in rvb_frames(reqnum_frames)])
+            paths.set(reproject_files(paths.paths[0], paths.paths))
+        jpg_path = convert_to_jpg(paths.paths, key, **params)
+        upload_to_s3(key, jpg_path)
     finally:
         # Cleanup actions
-        if jpg_path:
+        if jpg_path and os.path.exists(jpg_path):
             os.remove(jpg_path)
-        for path in paths:
-            os.remove(path)
+        for path in paths.all_paths:
+            if os.path.exists(path):
+                os.remove(path)
     return generate_url(key)
 
 
 def handle_response(frame, request):
+    if not can_generate_thumbnail_on(frame):
+        raise ThumbnailAppException('Cannot generate thumbnail on given frame', status_code=400)
+
     url = generate_thumbnail(frame, request)
     if request.args.get('image'):
         return redirect(url)
@@ -157,12 +282,15 @@ def bn_thumbnail(frame_basename):
     headers = {
         'Authorization': request.headers.get('Authorization')
     }
-    frames = requests.get(
-        '{0}frames/?basename={1}'.format(ARCHIVE_API, frame_basename),
+    frames = get_response(
+        f'{settings.ARCHIVE_API}frames/',
+        params={'basename': frame_basename},
         headers=headers
     ).json()
-    if not 0 < frames['count'] < 2:
-        abort(404)
+
+    if not frames['count'] == 1:
+        raise ThumbnailAppException('Frame not found', status_code=404)
+
     return handle_response(frames['results'][0], request)
 
 
@@ -171,12 +299,8 @@ def thumbnail(frame_id):
     headers = {
         'Authorization': request.headers.get('Authorization')
     }
-    frame = requests.get(
-        '{0}frames/{1}/'.format(ARCHIVE_API, frame_id),
-        headers=headers
-    ).json()
-    if frame.get('detail') == 'Not found.':
-        abort(404)
+    frame = get_response(f'{settings.ARCHIVE_API}frames/{frame_id}/', headers=headers).json()
+
     return handle_response(frame, request)
 
 

--- a/thumbservice.py
+++ b/thumbservice.py
@@ -209,15 +209,22 @@ def rvb_frames(frames):
 
 
 def reproject_files(ref_image, images_to_align):
-    identifications = make_transforms(ref_image, images_to_align[1:3])
-
     aligned_images = []
-    for id in identifications:
-        if id.ok:
-            aligned_img = affineremap(id.ukn.filepath, id.trans, outdir=settings.TMP_DIR)
-            aligned_images.append(aligned_img)
-    img_list = [ref_image]+aligned_images
 
+    try:
+        identifications = make_transforms(ref_image, images_to_align[1:3])
+        for id in identifications:
+            if id.ok:
+                aligned_img = affineremap(id.ukn.filepath, id.trans, outdir=settings.TMP_DIR)
+                aligned_images.append(aligned_img)
+    except Exception:
+        app.logger.error('Error aligning images, falling back to original image list', exc_info=True)
+        # Clean up any images that were created
+        for image in aligned_images:
+            if os.path.exists(image):
+                os.remove(image)
+
+    img_list = [ref_image]+aligned_images
     if len(img_list) != 3:
         return images_to_align
     return img_list

--- a/thumbservice.py
+++ b/thumbservice.py
@@ -64,6 +64,14 @@ def handle_thumbnail_app_exception(error):
     return response
 
 
+@app.errorhandler(Exception)
+def handle_broad_exceptions(error):
+    app.logger.error(error, exc_info=True)
+    response = jsonify({'message': 'Internal server error'})
+    response.status_code = 500
+    return response
+
+
 def get_response(url, params=None, headers=None):
     response = None
     try:
@@ -115,7 +123,7 @@ def can_generate_thumbnail_on(frame, request):
         return {'result': False, 'reason': f'Cannot generate color thumbnail for OBSTYPE={obstype}'}
 
     if not is_fits_file:
-        return {'result': False, 'reason': 'Cannot generate thumbnail for non FITS-type image'}
+        return {'result': False, 'reason': 'Cannot generate thumbnail for non FITS-type frame'}
 
     return {'result': True, 'reason': ''}
 

--- a/thumbservice.py
+++ b/thumbservice.py
@@ -3,8 +3,10 @@ import os
 import uuid
 
 import boto3
+import logging
 import requests
 from flask_cors import CORS
+from flask.logging import default_handler
 from flask import Flask, request, jsonify, redirect
 from fits2image.conversions import fits_to_jpg
 from fits_align.ident import make_transforms
@@ -12,6 +14,15 @@ from fits_align.align import affineremap
 
 app = Flask(__name__)
 CORS(app)
+
+
+class RequestFormatter(logging.Formatter):
+    def format(self, record):
+        record.url = request.url
+        return super().format(record)
+
+formatter = RequestFormatter('[%(asctime)s] %(levelname)s in %(module)s for %(url)s: %(message)s')
+default_handler.setFormatter(formatter)
 
 
 class Settings:
@@ -36,7 +47,6 @@ class Settings:
     @staticmethod
     def end_with_slash(path):
         return os.path.join(path, '')
-
 
 settings = Settings()
 


### PR DESCRIPTION
This PR addresses [issue 846](https://lcoglobal.redmineup.com/issues/846)

Things in this PR:
- Check a frame to see if it can be made into a thumbnail before proceeding with thumbnail generation
- Use [API exceptions](http://flask.pocoo.org/docs/1.0/patterns/apierrors/)
- Make sure all temp files are cleaned up. Some temp files were not being cleaned up for color thumbnail generation - the filenames returned from `reproject_files` overwrote the original filenames passed in, so those original files did not get cleaned up. 

I also updated some packages and added tests. For the tests, the [moto](https://github.com/spulec/moto) library is used to mock out aws calls. [requests_mock](https://requests-mock.readthedocs.io/en/latest/pytest.html) is used as a pytest fixture.