### PR TITLE
Fix/stable hash

### DIFF
--- a/thumbservice.py
+++ b/thumbservice.py
@@ -115,7 +115,7 @@ def save_temp_file(frame):
 
 
 def key_for_jpeg(frame_id, **params):
-    return f'{frame_id}.{hashlib.blake2s(repr(frozenset(params.items())).encode()).hexdigest()}.jpg'
+    return f'{frame_id}.{hashlib.blake2b(repr(frozenset(params.items())).encode(), digest_size=20).hexdigest()}.jpg'
 
 
 def convert_to_jpg(paths, key, **params):

--- a/thumbservice.py
+++ b/thumbservice.py
@@ -115,7 +115,7 @@ def save_temp_file(frame):
 
 
 def key_for_jpeg(frame_id, **params):
-    return f'{frame_id}.{hashlib.blake2b(repr(frozenset(params.items())).encode(), digest_size=32).hexdigest()}.jpg'
+    return f'{frame_id}.{hashlib.blake2s(repr(frozenset(params.items())).encode()).hexdigest()}.jpg'
 
 
 def convert_to_jpg(paths, key, **params):

--- a/thumbservice.py
+++ b/thumbservice.py
@@ -2,6 +2,7 @@
 import os
 import uuid
 import logging
+import hashlib
 
 import boto3
 import requests
@@ -114,7 +115,7 @@ def save_temp_file(frame):
 
 
 def key_for_jpeg(frame_id, **params):
-    return f'{frame_id}.{hash(frozenset(params.items()))}.jpg'
+    return f'{frame_id}.{hashlib.blake2b(repr(frozenset(params.items())).encode(), digest_size=32).hexdigest()}.jpg'
 
 
 def convert_to_jpg(paths, key, **params):


### PR DESCRIPTION
We have been using the builtin `hash()` function, which produces different hashes for the same inputs when run by the different replicas of the app, so we have probably been re-generating some of the same thumbnails that are already in s3. I updated the hash to use the `blake2` algorithm, which generates hashes of length 64 by default. The hashes that we have been using have been 20 characters long. I think this increase is ok since s3 keys can be up to 1024 characters long, but let me know if you can think of any reason longer keys might be a problem.